### PR TITLE
Add root endpoint to main application

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,10 @@ app = FastAPI()
 
 app.include_router(api_router, prefix="/api")
 
+@app.get("/")
+def read_root():
+    return {"message": "Welcome to the FastAPI application!"}
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
**Description**
This Pull Request adds a root test route to facilitate diagnosis in the FastAPI application.

**Changes**
Added a root test route in main.py to allow quick verification of the application's functionality at the root path.

**Test**

- Run the FastAPI application locally:
- Start the application using Uvicorn: uvicorn app.main:app --reload
- Verify the root route:
- Open a web browser and navigate to http://localhost:8000/
- Confirm that the response message is: {"message": "Welcome to the FastAPI application!"}